### PR TITLE
Fix reconnection location

### DIFF
--- a/src/js/packages/@reactpy/client/src/reactpy-client.ts
+++ b/src/js/packages/@reactpy/client/src/reactpy-client.ts
@@ -163,7 +163,7 @@ enum messageTypes {
 export class SimpleReactPyClient
   extends BaseReactPyClient
   implements ReactPyClient {
-  private readonly urls: ServerUrls;
+  private urls: ServerUrls;
   private socket!: { current?: WebSocket };
   private idleDisconnectTimeMillis: number;
   private lastActivityTime: number;
@@ -184,12 +184,14 @@ export class SimpleReactPyClient
   private socketLoopThrottle: number;
   private pingPongIntervalId?: number | null;
   private pingInterval: number;
+  serverLocation: LocationProps | undefined;
 
   constructor(props: SimpleReactPyClientProps) {
     super();
 
+    this.serverLocation = props.serverLocation;
     this.urls = getServerUrls(
-      props.serverLocation || {
+      this.serverLocation || {
         url: document.location.origin,
         route: document.location.pathname,
         query: document.location.search,
@@ -389,6 +391,14 @@ export class SimpleReactPyClient
     }
     lastAttempt = lastAttempt || Date.now();
     this.shouldReconnect = true;
+
+    this.urls = getServerUrls(
+      this.serverLocation || {
+        url: document.location.origin,
+        route: document.location.pathname,
+        query: document.location.search,
+      },
+    );
 
     window.setTimeout(() => {
       if (!this.didReconnectingCallback && this.reconnectingCallback && maxRetries != connectionAttemptsRemaining) {

--- a/src/js/packages/@reactpy/client/src/reactpy-client.ts
+++ b/src/js/packages/@reactpy/client/src/reactpy-client.ts
@@ -189,9 +189,8 @@ export class SimpleReactPyClient
   constructor(props: SimpleReactPyClientProps) {
     super();
 
-    this.serverLocation = props.serverLocation;
     this.urls = getServerUrls(
-      this.serverLocation || {
+      props.serverLocation || {
         url: document.location.origin,
         route: document.location.pathname,
         query: document.location.search,
@@ -393,7 +392,7 @@ export class SimpleReactPyClient
     this.shouldReconnect = true;
 
     this.urls = getServerUrls(
-      this.serverLocation || {
+      {
         url: document.location.origin,
         route: document.location.pathname,
         query: document.location.search,

--- a/src/js/packages/@reactpy/client/src/reactpy-client.ts
+++ b/src/js/packages/@reactpy/client/src/reactpy-client.ts
@@ -184,7 +184,6 @@ export class SimpleReactPyClient
   private socketLoopThrottle: number;
   private pingPongIntervalId?: number | null;
   private pingInterval: number;
-  serverLocation: LocationProps | undefined;
 
   constructor(props: SimpleReactPyClientProps) {
     super();


### PR DESCRIPTION
This fixes a bug where on reconnection it would revert back to your original URL even though the window clearly showed a different URL. The issue was that the URL used by client is locked in on page load and location is stored using a state var, so when it does a reconnection and has to rebuild the state, it loses the location as well. This would seem to imply the bug only affected cases where state rebuild failed, although it seemed more prevalent than that to me.