### PR TITLE
James-fix-missing-state-update-on-use-state

### DIFF
--- a/src/py/reactpy/reactpy/core/hooks.py
+++ b/src/py/reactpy/reactpy/core/hooks.py
@@ -23,7 +23,7 @@ from typing import (
 from typing_extensions import TypeAlias
 
 from reactpy.config import REACTPY_DEBUG_MODE
-from reactpy.core._life_cycle_hook import get_current_hook
+from reactpy.core._life_cycle_hook import LifeCycleHook, get_current_hook
 from reactpy.core.state_recovery import StateRecoveryFailureError
 from reactpy.core.types import Context, Key, State, VdomDict
 from reactpy.utils import Ref
@@ -78,8 +78,10 @@ def use_state(
     Returns:
         A tuple containing the current state and a function to update it.
     """
+    hook: LifeCycleHook | None
     if server_only:
         key = None
+        hook = None
     else:
         hook = get_current_hook()
         caller_info = get_caller_info()
@@ -92,6 +94,8 @@ def use_state(
                     f"Missing expected key {key} on client"
                 ) from err
     current_state = _use_const(lambda: _CurrentState(key, initial_value))
+    if hook:
+        hook.add_state_update(current_state)
     return State(current_state.value, current_state.dispatch)
 
 


### PR DESCRIPTION
This fixes an issue where the initial state wasn't being kept track of. This meant the client was sometimes not updated with the latest state. Specifically:

```python
    def add_state_update(self, updated_state: _CurrentState | Ref) -> None:
        if (
            updated_state.key
            and self._previous_states.get(
                updated_state.key, "__missing_lifecycle_key_value__"
            )
            is not updated_state.value
        ):
            self._updated_states[updated_state.key] = updated_state.value
```

Would call `self._previous_states.get(updated_state.key)` and return the same value as the new value. I suppose an alternative fix might be to remove that check but I'm presuming its there for a reason. I haven't investigated removing it. I think this is a necessary change because on reconnection the initial state from the server may not match what the user had.

This specifically manifested in a case where switching values on one component would change another component to one with an identical structure. It would cause the state sent to the client to be either the initial state or the value of an effect, in alternating fashion.

This likely the cause of some random reconnection instability I've seen from time to time.