### PR TITLE
Remove select as a special element

### DIFF
--- a/src/js/packages/@reactpy/client/src/components.tsx
+++ b/src/js/packages/@reactpy/client/src/components.tsx
@@ -219,6 +219,5 @@ function useImportSource(model: ReactPyVdom): MutableRefObject<any> {
 const SPECIAL_ELEMENTS = {
   input: UserInputElement,
   script: ScriptElement,
-  select: UserInputElement,
   textarea: UserInputElement,
 };


### PR DESCRIPTION
The special elements seem to "detach" from state updates. It's not clear why this is needed here - it was creating an issue where the selected dropdown was ignoring keys and always persisting if the options did not change. Removing this seems to fix the issue with no side effects.

In other words, the "options" were not updating in the children, so the selected option never updates to reflect the new value. This only happened after modifying the dropdown.