### PR TITLE
Provide feedback to the user when the internet is slow

### DIFF
--- a/src/js/packages/@reactpy/client/src/messages.ts
+++ b/src/js/packages/@reactpy/client/src/messages.ts
@@ -17,6 +17,10 @@ export type ReconnectingCheckMessage = {
   value: string;
 }
 
-export type IncomingMessage = LayoutUpdateMessage | ReconnectingCheckMessage;
+export type AckMessage = {
+  type: "ack"
+}
+
+export type IncomingMessage = LayoutUpdateMessage | ReconnectingCheckMessage | AckMessage;
 export type OutgoingMessage = LayoutEventMessage | ReconnectingCheckMessage;
 export type Message = IncomingMessage | OutgoingMessage;

--- a/src/js/packages/@reactpy/client/src/reactpy-client.ts
+++ b/src/js/packages/@reactpy/client/src/reactpy-client.ts
@@ -158,6 +158,7 @@ enum messageTypes {
   stateUpdate = "state-update",
   layoutUpdate = "layout-update",
   pingIntervalSet = "ping-interval-set",
+  ackMessage = "ack"
 };
 
 export class SimpleReactPyClient
@@ -223,6 +224,7 @@ export class SimpleReactPyClient
       this.willReconnect = true;  // don't indicate a reconnect until at least one successful layout update
     });
     this.onMessage(messageTypes.pingIntervalSet, (msg) => { this.pingInterval = msg.ping_interval; this.updatePingInterval(); });
+    this.onMessage(messageTypes.ackMessage, () => {})
     this.updatePingInterval()
     this.reconnect()
 

--- a/src/py/reactpy/reactpy/core/serve.py
+++ b/src/py/reactpy/reactpy/core/serve.py
@@ -18,6 +18,7 @@ from reactpy.core._life_cycle_hook import clear_hook_state, create_hook_state
 from reactpy.core.layout import Layout
 from reactpy.core.state_recovery import StateRecoveryFailureError, StateRecoveryManager
 from reactpy.core.types import (
+    AckMessage,
     ClientStateMessage,
     IsReadyMessage,
     LayoutEventMessage,

--- a/src/py/reactpy/reactpy/core/serve.py
+++ b/src/py/reactpy/reactpy/core/serve.py
@@ -127,9 +127,8 @@ async def _single_incoming_loop(
         # We need to fire and forget here so that we avoid waiting on the completion
         # of this event handler before receiving and running the next one.
 
-        task_group.start_soon(send, AckMessage(type="ack"))
         task_group.start_soon(layout.deliver, await recv())
-
+        task_group.start_soon(send, AckMessage(type="ack"))
 
 class WebsocketServer:
     def __init__(

--- a/src/py/reactpy/reactpy/core/serve.py
+++ b/src/py/reactpy/reactpy/core/serve.py
@@ -126,6 +126,7 @@ async def _single_incoming_loop(
         # We need to fire and forget here so that we avoid waiting on the completion
         # of this event handler before receiving and running the next one.
         task_group.start_soon(layout.deliver, await recv())
+        await send(AckMessage(type="ack"))
 
 
 class WebsocketServer:

--- a/src/py/reactpy/reactpy/core/serve.py
+++ b/src/py/reactpy/reactpy/core/serve.py
@@ -126,8 +126,9 @@ async def _single_incoming_loop(
     while True:
         # We need to fire and forget here so that we avoid waiting on the completion
         # of this event handler before receiving and running the next one.
+
+        task_group.start_soon(send, AckMessage(type="ack"))
         task_group.start_soon(layout.deliver, await recv())
-        await send(AckMessage(type="ack"))
 
 
 class WebsocketServer:

--- a/src/py/reactpy/reactpy/core/types.py
+++ b/src/py/reactpy/reactpy/core/types.py
@@ -269,6 +269,10 @@ class PingIntervalSetMessage(TypedDict):
     ping_interval: int
 
 
+class AckMessage(TypedDict):
+    type: Literal["ack-message"]
+
+
 class Context(Protocol[_Type]):
     """Returns a :class:`ContextProvider` component"""
 


### PR DESCRIPTION
This displays the reconnecting grayout if the client sends an action and has to wait or over 800 ms for a response. The server now returns an acknowledgement message after every received message since it currently only returns a message if there's a new render.